### PR TITLE
Introduce pipeline interceptors scoped to a specific payload type

### DIFF
--- a/PipelineFramework.DI.sln
+++ b/PipelineFramework.DI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.271
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BE430022-FA46-4178-9E40-3673B2D1A0DA}"
 EndProject
@@ -26,6 +26,8 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\SharedInfrastructure\SharedInfrastructure.projitems*{2d757ac7-38da-4172-b969-99825096c8a4}*SharedItemsImports = 13
+		tests\SharedInfrastructure\SharedInfrastructure.projitems*{5fba3f0c-dd74-4efa-9965-92ecbd115e78}*SharedItemsImports = 5
+		tests\SharedInfrastructure\SharedInfrastructure.projitems*{da370e23-d7e6-4c5c-8990-8e2bbd24b60a}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/PipelineFramework.LightInject/Interception/PayloadScopedPipelineComponentAsyncInterceptorBase.cs
+++ b/src/PipelineFramework.LightInject/Interception/PayloadScopedPipelineComponentAsyncInterceptorBase.cs
@@ -1,0 +1,31 @@
+﻿using LightInject.Interception;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PipelineFramework.LightInject.Interception
+{
+    public abstract class PayloadScopedPipelineComponentAsyncInterceptorBase<TPayload> : AsyncInterceptor where TPayload : class
+    {
+        protected PayloadScopedPipelineComponentAsyncInterceptorBase() : base(null)
+        {
+        }
+
+        protected override Task<T> InvokeAsync<T>(IInvocationInfo invocationInfo)
+        {
+            if (!(invocationInfo.Arguments.FirstOrDefault() is TPayload payload))
+            {
+                throw new InvalidOperationException(
+                    $"Expected first parameter of intercepted method {invocationInfo.Method.Name} to have parameter of type {nameof(TPayload)}");
+            }
+            BeforeExecute(payload);
+            var task = base.InvokeAsync<T>(invocationInfo);
+            AfterExecute(payload);
+            return task;
+        }
+
+        protected  abstract void BeforeExecute(TPayload payload);
+
+        protected abstract void AfterExecute(TPayload payload);
+    }
+}

--- a/src/PipelineFramework.LightInject/PipelineFramework.LightInject.csproj
+++ b/src/PipelineFramework.LightInject/PipelineFramework.LightInject.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/gtmoose32/pipeline-framework-di</RepositoryUrl>
     <PackageProjectUrl>https://github.com/gtmoose32/pipeline-framework-di</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>4.0.0</Version>
+    <Version>4.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Extends PipelineFramework to enable LightInject DI container for pipeline construction and execution</Description>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/PipelineFramework.LightInject/ServiceFactoryExtensions.cs
+++ b/src/PipelineFramework.LightInject/ServiceFactoryExtensions.cs
@@ -5,10 +5,7 @@ namespace PipelineFramework.LightInject
 {
     public static class ServiceFactoryExtensions
     {
-        public static IInterceptor GetAsyncInterceptor(this IServiceFactory factory) 
-            => factory.GetInstance<AsyncInterceptor>();
-
-        public static IInterceptor GetInterceptor(this IServiceFactory factory) 
-            => factory.GetInstance<IInterceptor>();
+        public static IInterceptor GetInterceptor<TInterceptor>(this IServiceFactory factory) where TInterceptor : IInterceptor
+            => factory.GetInstance<TInterceptor>();
     }
 }

--- a/src/PipelineFramework.LightInject/ServiceRegistryExtensions.cs
+++ b/src/PipelineFramework.LightInject/ServiceRegistryExtensions.cs
@@ -184,7 +184,7 @@ namespace PipelineFramework.LightInject
             => (factory, proxy) => proxy.Implement(factory.GetInterceptor<TInterceptor>, mi => mi.Name == "Execute");
 
         private static Action<IServiceFactory, ProxyDefinition> AsyncInterceptorProxyDefinition<TInterceptor>()
-            where TInterceptor : IInterceptor
+            where TInterceptor : AsyncInterceptor
             => (factory, proxy) => proxy.Implement(factory.GetInterceptor<TInterceptor>, mi => mi.Name == "ExecuteAsync");
 
         #endregion

--- a/tests/PipelineFramework.LightInject.Tests/Interception/PipelineComponentAsyncInterceptorBaseTests.cs
+++ b/tests/PipelineFramework.LightInject.Tests/Interception/PipelineComponentAsyncInterceptorBaseTests.cs
@@ -1,0 +1,108 @@
+﻿using FluentAssertions;
+using LightInject;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using PipelineFramework.Abstractions;
+using PipelineFramework.LightInject.Interception;
+using PipelineFramework.Tests.SharedInfrastructure;
+using Serilog;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PipelineFramework.LightInject.Tests.Interception
+{
+    [ExcludeFromCodeCoverage]
+    [TestClass]
+    //[Ignore]
+    public class PipelineComponentAsyncInterceptorBaseTests
+    {
+        private IServiceContainer _container;
+        private ILogger _logger;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _container = new ServiceContainer();
+            _logger = Substitute.For<ILogger>();
+            _logger.ForContext(Arg.Any<string>(), Arg.Any<string>())
+                .Returns(_logger);
+            _container.RegisterInstance(_logger);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _container?.Dispose();
+        }
+
+        [TestMethod]
+        public async Task InterceptorInvokedForMatchingPayloadType()
+        {
+            // Arrange
+            _container.AddPayloadScopedPipelineAsyncInterceptor<CustomPayloadInterceptor, InterceptorTestPayload>();
+            _container.Register<IAsyncPipelineComponent<InterceptorTestPayload>, PayloadInterceptorAsyncTestComponent>();
+            
+            var component = _container.GetInstance<IAsyncPipelineComponent<InterceptorTestPayload>>();
+
+            // Act
+            var result = await component.ExecuteAsync(new InterceptorTestPayload(), CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Count.Should().Be(1);
+
+            _logger.Received().Information("Before");
+            _logger.Received().Information("After");
+        }
+
+        [TestMethod]
+        public async Task InterceptorNotInvokedForUnmatchedPayloadType()
+        {
+            // Arrange
+            _container.AddPayloadScopedPipelineAsyncInterceptor<CustomPayloadInterceptor, InterceptorTestPayload>();
+            _container.Register<IAsyncPipelineComponent<TestPayload>, AsyncTestComponent>();
+
+            var component = _container.GetInstance<IAsyncPipelineComponent<TestPayload>>();
+
+            // Act
+            var result = await component.ExecuteAsync(new TestPayload(), CancellationToken.None);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Count.Should().Be(1);
+            _logger.DidNotReceiveWithAnyArgs().Information(null);
+        }
+
+        public class CustomPayloadInterceptor : PayloadScopedPipelineComponentAsyncInterceptorBase<InterceptorTestPayload>
+        {
+            private readonly ILogger _logger;
+
+            public CustomPayloadInterceptor(ILogger logger)
+            {
+                _logger = logger;
+            }
+
+            protected override void BeforeExecute(InterceptorTestPayload payload)
+            {
+                _logger.Information("Before");
+            }
+
+            protected override void AfterExecute(InterceptorTestPayload payload)
+            {
+                _logger.Information("After");
+            }
+        }
+
+        public class InterceptorTestPayload : TestPayload { }
+
+        public class PayloadInterceptorAsyncTestComponent : AsyncPipelineComponentBase<InterceptorTestPayload>
+        {
+            public override Task<InterceptorTestPayload> ExecuteAsync(InterceptorTestPayload payload, CancellationToken cancellationToken)
+            {
+                payload.Count++;
+                return Task.FromResult(payload);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added PayloadScopedPipelineComponentAsyncInterceptorBase
- Cleanup of ServiceRegistryExtensions for code reuse
- Fixed an issue during interceptor registration where incorrect interceptor may be obtained from container at runtime