### PR TITLE
Make logging component extension constraints more strict

### DIFF
--- a/src/PipelineFramework.LightInject/PipelineFramework.LightInject.csproj
+++ b/src/PipelineFramework.LightInject/PipelineFramework.LightInject.csproj
@@ -8,7 +8,7 @@
     <RepositoryUrl>https://github.com/gtmoose32/pipeline-framework-di</RepositoryUrl>
     <PackageProjectUrl>https://github.com/gtmoose32/pipeline-framework-di</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Description>Extends PipelineFramework to enable LightInject DI container for pipeline construction and execution</Description>
     <NeutralLanguage>en</NeutralLanguage>

--- a/src/PipelineFramework.LightInject/ServiceRegistryExtensions.cs
+++ b/src/PipelineFramework.LightInject/ServiceRegistryExtensions.cs
@@ -64,7 +64,7 @@ namespace PipelineFramework.LightInject
         /// <typeparam name="TInterceptor"></typeparam>
         /// <param name="serviceRegistry"></param>
         public static void AddAsyncPipelineComponentLogging<TInterceptor>(this IServiceRegistry serviceRegistry)
-            where TInterceptor : AsyncInterceptor
+            where TInterceptor : AsyncPipelineComponentInterceptor
         {
             serviceRegistry.Register<TInterceptor>();
 
@@ -92,7 +92,7 @@ namespace PipelineFramework.LightInject
         /// <typeparam name="TInterceptor"></typeparam>
         /// <param name="serviceRegistry"></param>
         public static void AddPipelineComponentLogging<TInterceptor>(this IServiceRegistry serviceRegistry)
-            where TInterceptor : IInterceptor
+            where TInterceptor : PipelineComponentInterceptor
         {
             serviceRegistry.Register<TInterceptor>();
 


### PR DESCRIPTION
- Add `Logging.AsyncPipelineComponentInterceptor` constraint to `ServiceRegistryExtensions.AddAsyncPipelineComponentLogging`
- Add `Logging.PipelineComponentInterceptor` constraint to `ServiceRegistryExtensions.AddPipelineComponentLogging`