### PR TITLE
Fix build status and nuget push 409 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pipeline Framework Dependency Injection
-[![Build status](https://dev.azure.com/gtmoose/Mathis%20Home/_apis/build/status/Pipeline%20Framework/Pipeline%20Framework%20DI%20-%20CICD)](https://dev.azure.com/gtmoose/Mathis%20Home/_build/latest?definitionId=7)
+![Build Status](https://dev.azure.com/gtmoose/Mathis%20Home/_apis/build/status/Pipeline%20Framework/pipeline-framework-di?branchName=master)
 
 ## What is it?
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,9 +46,9 @@ steps:
 - task: NuGetCommand@2
   displayName: Publish
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranchName'], 'master'))
+  continueOnError: true
   inputs:
     command: push
     packagesToPack: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
-    allowPackageConflicts: true
     nuGetFeedType: external
     publishFeedCredentials: nuget.org


### PR DESCRIPTION
- Fix link to build status badge
- Allow nuget push to continue on error in version has not changed for a package